### PR TITLE
Here are my changes to add support for binding to simple properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 project.xcworkspace
 xcuserdata
+
+.DS_Store

--- a/KVOBlockBinding/NSObject+KVOBlockBinding.h
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.h
@@ -66,7 +66,16 @@ typedef void (^WSObservationBlock)(id observed, NSDictionary *change);
                          keyPath:(NSString *)keyPath
                            block:(WSObservationBlock)block;
 
-- (NSArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath;
+/**
+ * Sets up keypath binding between the source and target objects.  
+ *
+ * @param source The source object to observe
+ * @param sourcePath The keypath of the property to observe on the source using KVO
+ * @param target The target object to observe
+ * @param targetPath The keypath of the property to observe on the target using KVO
+ * @return An array containing the binding and it's reverse, if specified. This does NOT need to be retained
+ */
+- (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath addReverseBinding:(BOOL)addReverseBinding;
 @end
 
 @interface NSObject (KVOBlockBinding)

--- a/KVOBlockBinding/NSObject+KVOBlockBinding.h
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.h
@@ -65,6 +65,8 @@ typedef void (^WSObservationBlock)(id observed, NSDictionary *change);
 - (WSObservationBinding*)observe:(id)object 
                          keyPath:(NSString *)keyPath
                            block:(WSObservationBlock)block;
+
+- (NSArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath;
 @end
 
 @interface NSObject (KVOBlockBinding)

--- a/KVOBlockBinding/NSObject+KVOBlockBinding.m
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.m
@@ -40,7 +40,7 @@
                         change:(NSDictionary *)change 
                        context:(void *)context
 {
-    if(self.valid)
+    if(self.valid && ![[change valueForKey:NSKeyValueChangeNewKey] isEqual:[change valueForKey:NSKeyValueChangeOldKey]]) 
         self.block(self.observed, change);
 }
 
@@ -125,6 +125,19 @@
                  keyPath:keyPath 
                  options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld 
                    block:block];
+}
+- (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath {
+    NSMutableArray *bindings = [[[NSMutableArray alloc] init] autorelease];
+    
+    [bindings addObject:[self observe:source keyPath:sourcePath block:^(id observed, NSDictionary *change) {
+        [target setValue:[change valueForKey:NSKeyValueChangeNewKey] forKey:targetPath];
+    }]];
+    
+    [bindings addObject:[self observe:target keyPath:targetPath block:^(id observed, NSDictionary *change) {
+        [source setValue:[change valueForKey:NSKeyValueChangeNewKey] forKey:sourcePath];
+    }]];
+
+    return bindings;
 }
 
 @end

--- a/KVOBlockBinding/NSObject+KVOBlockBinding.m
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.m
@@ -126,16 +126,18 @@
                  options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld 
                    block:block];
 }
-- (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath {
+- (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath addReverseBinding:(BOOL)addReverseBinding {
     NSMutableArray *bindings = [[[NSMutableArray alloc] init] autorelease];
     
     [bindings addObject:[self observe:source keyPath:sourcePath block:^(id observed, NSDictionary *change) {
         [target setValue:[change valueForKey:NSKeyValueChangeNewKey] forKey:targetPath];
     }]];
     
-    [bindings addObject:[self observe:target keyPath:targetPath block:^(id observed, NSDictionary *change) {
-        [source setValue:[change valueForKey:NSKeyValueChangeNewKey] forKey:sourcePath];
-    }]];
+    if (addReverseBinding) {
+        [bindings addObject:[self observe:target keyPath:targetPath block:^(id observed, NSDictionary *change) {
+            [source setValue:[change valueForKey:NSKeyValueChangeNewKey] forKey:sourcePath];
+        }]];
+    }
 
     return bindings;
 }

--- a/KVOBlockBindingExample/KVOBlockBindingViewController.h
+++ b/KVOBlockBindingExample/KVOBlockBindingViewController.h
@@ -11,6 +11,10 @@
 }
 
 @property (nonatomic, retain) ExampleModel *model;
+@property (retain, nonatomic) IBOutlet UIStepper *stepper1;
+@property (retain, nonatomic) IBOutlet UIStepper *stepper2;
+@property (retain, nonatomic) IBOutlet UILabel *stepper1Label;
+@property (retain, nonatomic) IBOutlet UILabel *stepper2Label;
 
 -(IBAction)pressMeButtonPressed:(id)sender;
 -(IBAction)toggleObservingValue2ButtonPressed:(id)sender;

--- a/KVOBlockBindingExample/KVOBlockBindingViewController.m
+++ b/KVOBlockBindingExample/KVOBlockBindingViewController.m
@@ -4,10 +4,18 @@
 
 @implementation KVOBlockBindingViewController
 @synthesize model;
+@synthesize stepper1;
+@synthesize stepper2;
+@synthesize stepper1Label;
+@synthesize stepper2Label;
 
 - (void)dealloc
 {
-    self.model = nil;
+    self.model = nil;   
+    [stepper1 release];
+    [stepper2 release];
+    [stepper1Label release];
+    [stepper2Label release];
     [super dealloc];
 }
 
@@ -15,7 +23,7 @@
 {
     toggleObservingValue1Button.selected = YES;
     [toggleObservingValue1Button setTitle:@"Stop Observing Value1" forState:UIControlStateNormal];
-    [self.model addObserverForKeyPath:@"exampleValue1" owner:self block:^(NSDictionary *change) {
+    [self.model addObserverForKeyPath:@"exampleValue1" owner:self block:^(id observed, NSDictionary *change) {
         label1.text = [NSString stringWithFormat:@"%d", self.model.exampleValue1];
     }];
 }
@@ -24,9 +32,23 @@
 {
     toggleObservingValue2Button.selected = YES;
     [toggleObservingValue2Button setTitle:@"Stop Observing Value2" forState:UIControlStateNormal];
-    [self.model addObserverForKeyPath:@"exampleValue2" owner:self block:^(NSDictionary *change) {
+    [self.model addObserverForKeyPath:@"exampleValue2" owner:self block:^(id observed, NSDictionary *change) {
         label2.text = [NSString stringWithFormat:@"%@ -> %@", [change valueForKey:NSKeyValueChangeOldKey] , [change valueForKey:NSKeyValueChangeNewKey]];
     }];
+}
+
+-(void)twoWayBinding
+{
+    [self bind:stepper1 keyPath:@"value" to:stepper2 keyPath:@"value" addReverseBinding:YES];
+    
+    // add one way blocks to observe the stepper values
+    [self observe:stepper1 keyPath:@"value" block:^(id observed, NSDictionary *change) {       
+        stepper1Label.text = [NSString stringWithFormat:@"%1.0f",stepper1.value];
+    }];
+    [self observe:stepper2 keyPath:@"value" block:^(id observed, NSDictionary *change) {
+        stepper2Label.text = [NSString stringWithFormat:@"%1.0f",stepper2.value];
+    }];
+
 }
 
 -(void)removeObserverFromValue1
@@ -54,6 +76,8 @@
     
     [self bindObserverToValue1];
     [self bindObserverToValue2];
+    
+    [self twoWayBinding];
 }
 
 
@@ -79,4 +103,11 @@
     [self removeObserverFromValue2];
 }
 
+- (void)viewDidUnload {
+    [self setStepper1:nil];
+    [self setStepper2:nil];
+    [self setStepper1Label:nil];
+    [self setStepper2Label:nil];
+    [super viewDidUnload];
+}
 @end

--- a/KVOBlockBindingExample/en.lproj/KVOBlockBindingViewController.xib
+++ b/KVOBlockBindingExample/en.lproj/KVOBlockBindingViewController.xib
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1056</int>
-		<string key="IBDocument.SystemVersion">10J869</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1306</string>
-		<string key="IBDocument.AppKitVersion">1038.35</string>
-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<int key="IBDocument.SystemTarget">1280</int>
+		<string key="IBDocument.SystemVersion">11D50b</string>
+		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
+		<string key="IBDocument.AppKitVersion">1138.32</string>
+		<string key="IBDocument.HIToolboxVersion">568.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">301</string>
+			<string key="NS.object.0">933</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
 			<string>IBUIButton</string>
+			<string>IBUIStepper</string>
 			<string>IBUIView</string>
 			<string>IBUILabel</string>
 			<string>IBProxyObject</string>
@@ -22,11 +23,8 @@
 			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys" id="0">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-			<reference key="dict.values" ref="0"/>
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -63,6 +61,15 @@
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">1</int>
 						<float key="IBUIMinimumFontSize">10</float>
+						<object class="IBUIFontDescription" key="IBUIFontDescription" id="28118554">
+							<int key="type">1</int>
+							<double key="pointSize">17</double>
+						</object>
+						<object class="NSFont" key="IBUIFont" id="807711747">
+							<string key="NSName">Helvetica</string>
+							<double key="NSSize">17</double>
+							<int key="NSfFlags">16</int>
+						</object>
 					</object>
 					<object class="IBUILabel" id="658642049">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -81,6 +88,8 @@
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">1</int>
 						<float key="IBUIMinimumFontSize">10</float>
+						<reference key="IBUIFontDescription" ref="28118554"/>
+						<reference key="IBUIFont" ref="807711747"/>
 					</object>
 					<object class="IBUIButton" id="234904344">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -93,11 +102,6 @@
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<object class="NSFont" key="IBUIFont" id="379512704">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
 						<int key="IBUIButtonType">1</int>
 						<string key="IBUINormalTitle">Update Model values</string>
 						<object class="NSColor" key="IBUIHighlightedTitleColor" id="114592505">
@@ -112,6 +116,17 @@
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MC41AA</bytes>
 						</object>
+						<object class="IBUIFontDescription" key="IBUIFontDescription" id="460301458">
+							<string key="name">Helvetica-Bold</string>
+							<string key="family">Helvetica</string>
+							<int key="traits">2</int>
+							<double key="pointSize">15</double>
+						</object>
+						<object class="NSFont" key="IBUIFont" id="379512704">
+							<string key="NSName">Helvetica-Bold</string>
+							<double key="NSSize">15</double>
+							<int key="NSfFlags">16</int>
+						</object>
 					</object>
 					<object class="IBUIButton" id="484771841">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -119,12 +134,11 @@
 						<string key="NSFrame">{{43, 249}, {234, 37}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="234904344"/>
+						<reference key="NSNextKeyView" ref="672747829"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<reference key="IBUIFont" ref="379512704"/>
 						<int key="IBUIButtonType">1</int>
 						<string key="IBUINormalTitle">Stop Observing All KeyPaths</string>
 						<reference key="IBUIHighlightedTitleColor" ref="114592505"/>
@@ -133,6 +147,8 @@
 							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
 						</object>
 						<reference key="IBUINormalTitleShadowColor" ref="983357434"/>
+						<reference key="IBUIFontDescription" ref="460301458"/>
+						<reference key="IBUIFont" ref="379512704"/>
 					</object>
 					<object class="IBUIButton" id="454818801">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -145,7 +161,6 @@
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<reference key="IBUIFont" ref="379512704"/>
 						<int key="IBUIButtonType">1</int>
 						<string key="IBUINormalTitle">Stop Observing Value 1</string>
 						<reference key="IBUIHighlightedTitleColor" ref="114592505"/>
@@ -154,6 +169,8 @@
 							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
 						</object>
 						<reference key="IBUINormalTitleShadowColor" ref="983357434"/>
+						<reference key="IBUIFontDescription" ref="460301458"/>
+						<reference key="IBUIFont" ref="379512704"/>
 					</object>
 					<object class="IBUIButton" id="272968959">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -166,7 +183,6 @@
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<reference key="IBUIFont" ref="379512704"/>
 						<int key="IBUIButtonType">1</int>
 						<string key="IBUINormalTitle">Stop Observing Value 2</string>
 						<reference key="IBUIHighlightedTitleColor" ref="114592505"/>
@@ -175,6 +191,105 @@
 							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
 						</object>
 						<reference key="IBUINormalTitleShadowColor" ref="983357434"/>
+						<reference key="IBUIFontDescription" ref="460301458"/>
+						<reference key="IBUIFont" ref="379512704"/>
+					</object>
+					<object class="IBUILabel" id="672747829">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{95, 301}, {131, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="966638923"/>
+						<string key="NSReuseIdentifierKey">_NS:328</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Two-way Binding</string>
+						<reference key="IBUITextColor" ref="6115602"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+						<reference key="IBUIFontDescription" ref="28118554"/>
+						<reference key="IBUIFont" ref="807711747"/>
+					</object>
+					<object class="IBUIStepper" id="966638923">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{43, 330}, {94, 27}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="825091344"/>
+						<string key="NSReuseIdentifierKey">_NS:992</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<double key="IBUIValue">5</double>
+						<double key="IBUIMaximumValue">10</double>
+					</object>
+					<object class="IBUIStepper" id="825091344">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{183, 330}, {94, 27}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="270208336"/>
+						<string key="NSReuseIdentifierKey">_NS:992</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<double key="IBUIValue">5</double>
+						<double key="IBUIMaximumValue">10</double>
+					</object>
+					<object class="IBUILabel" id="270208336">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{69, 365}, {42, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="537170258"/>
+						<string key="NSReuseIdentifierKey">_NS:328</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">5</string>
+						<reference key="IBUITextColor" ref="6115602"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+						<int key="IBUITextAlignment">1</int>
+						<reference key="IBUIFontDescription" ref="28118554"/>
+						<reference key="IBUIFont" ref="807711747"/>
+					</object>
+					<object class="IBUILabel" id="537170258">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{209, 365}, {42, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="234904344"/>
+						<string key="NSReuseIdentifierKey">_NS:328</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">5</string>
+						<reference key="IBUITextColor" ref="6115602"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+						<int key="IBUITextAlignment">1</int>
+						<reference key="IBUIFontDescription" ref="28118554"/>
+						<reference key="IBUIFont" ref="807711747"/>
 					</object>
 				</object>
 				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
@@ -203,15 +318,6 @@
 						<reference key="destination" ref="774585933"/>
 					</object>
 					<int key="connectionID">7</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">pressMeButtonPressed:</string>
-						<reference key="source" ref="234904344"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">13</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchOutletConnection" key="connection">
@@ -254,6 +360,47 @@
 					<int key="connectionID">22</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">stepper1</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="966638923"/>
+					</object>
+					<int key="connectionID">43</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">stepper2</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="825091344"/>
+					</object>
+					<int key="connectionID">44</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">stepper1Label</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="270208336"/>
+					</object>
+					<int key="connectionID">47</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">stepper2Label</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="537170258"/>
+					</object>
+					<int key="connectionID">48</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">pressMeButtonPressed:</string>
+						<reference key="source" ref="234904344"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">13</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
 						<string key="label">removeObservingAllButtonPressed:</string>
 						<reference key="source" ref="484771841"/>
@@ -286,7 +433,9 @@
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<object class="IBObjectRecord">
 						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
+						<object class="NSArray" key="object" id="0">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+						</object>
 						<reference key="children" ref="1000"/>
 						<nil key="parent"/>
 					</object>
@@ -312,6 +461,11 @@
 							<reference ref="272968959"/>
 							<reference ref="234904344"/>
 							<reference ref="484771841"/>
+							<reference ref="672747829"/>
+							<reference ref="825091344"/>
+							<reference ref="966638923"/>
+							<reference ref="270208336"/>
+							<reference ref="537170258"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -345,6 +499,31 @@
 						<reference key="object" ref="272968959"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">30</int>
+						<reference key="object" ref="672747829"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">39</int>
+						<reference key="object" ref="966638923"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">40</int>
+						<reference key="object" ref="825091344"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">41</int>
+						<reference key="object" ref="270208336"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">42</int>
+						<reference key="object" ref="537170258"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -352,12 +531,18 @@
 				<object class="NSArray" key="dict.sortedKeys">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>-1.CustomClassName</string>
+					<string>-1.IBPluginDependency</string>
 					<string>-2.CustomClassName</string>
+					<string>-2.IBPluginDependency</string>
 					<string>10.IBPluginDependency</string>
 					<string>11.IBPluginDependency</string>
 					<string>16.IBPluginDependency</string>
 					<string>18.IBPluginDependency</string>
-					<string>6.IBEditorWindowLastContentRect</string>
+					<string>30.IBPluginDependency</string>
+					<string>39.IBPluginDependency</string>
+					<string>40.IBPluginDependency</string>
+					<string>41.IBPluginDependency</string>
+					<string>42.IBPluginDependency</string>
 					<string>6.IBPluginDependency</string>
 					<string>8.IBPluginDependency</string>
 					<string>9.IBPluginDependency</string>
@@ -365,12 +550,18 @@
 				<object class="NSMutableArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>KVOBlockBindingViewController</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>{{239, 654}, {320, 480}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -388,7 +579,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">25</int>
+			<int key="maxID">48</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -442,6 +633,10 @@
 							<string>label1</string>
 							<string>label2</string>
 							<string>removeObservingAllButton</string>
+							<string>stepper1</string>
+							<string>stepper1Label</string>
+							<string>stepper2</string>
+							<string>stepper2Label</string>
 							<string>toggleObservingValue1Button</string>
 							<string>toggleObservingValue2Button</string>
 						</object>
@@ -450,6 +645,10 @@
 							<string>UILabel</string>
 							<string>UILabel</string>
 							<string>UIButton</string>
+							<string>UIStepper</string>
+							<string>UILabel</string>
+							<string>UIStepper</string>
+							<string>UILabel</string>
 							<string>UIButton</string>
 							<string>UIButton</string>
 						</object>
@@ -461,6 +660,10 @@
 							<string>label1</string>
 							<string>label2</string>
 							<string>removeObservingAllButton</string>
+							<string>stepper1</string>
+							<string>stepper1Label</string>
+							<string>stepper2</string>
+							<string>stepper2Label</string>
 							<string>toggleObservingValue1Button</string>
 							<string>toggleObservingValue2Button</string>
 						</object>
@@ -477,6 +680,22 @@
 							<object class="IBToOneOutletInfo">
 								<string key="name">removeObservingAllButton</string>
 								<string key="candidateClassName">UIButton</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">stepper1</string>
+								<string key="candidateClassName">UIStepper</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">stepper1Label</string>
+								<string key="candidateClassName">UILabel</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">stepper2</string>
+								<string key="candidateClassName">UIStepper</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">stepper2Label</string>
+								<string key="candidateClassName">UILabel</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">toggleObservingValue1Button</string>
@@ -503,6 +722,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">301</string>
+		<string key="IBCocoaTouchPluginVersion">933</string>
 	</data>
 </archive>

--- a/KVOBlockBindingTests/KVOBlockBindingTests.m
+++ b/KVOBlockBindingTests/KVOBlockBindingTests.m
@@ -24,7 +24,7 @@
 - (void)bindTo:(NSString*)keyPath 
 {
     __block KVOBlockBindingTests *blockSelf = self;
-    self.binding = [self.model addObserverForKeyPath:keyPath owner:self block:^(NSDictionary *change) {
+    self.binding = [self.model addObserverForKeyPath:keyPath owner:self block:^(id observed, NSDictionary *change) {
         blockSelf->wasBlockCalled = YES;
     }];    
 }
@@ -91,5 +91,25 @@
     
     STAssertFalse(wasBlockCalled, @"Expected the block NOT to be called");
     [self.binding invalidate];
+}
+
+- (void) testTwoWayBinding
+{
+    NSMutableArray *bindings = [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES];
+    
+    self.model.exampleValue1 = 1; // no change
+    STAssertFalse(self.model.exampleValue2 == self.model.exampleValue1, @"Identical changes should not trigger an update of the target object");
+    
+    self.model.exampleValue1 = 10;
+    STAssertTrue(self.model.exampleValue2 == self.model.exampleValue1, @"Source/Target binding did not product expected result. Expected: %d, Actual: %d",self.model.exampleValue1,self.model.exampleValue2);
+    
+    self.model.exampleValue2 = 20;
+    STAssertTrue(self.model.exampleValue1 == self.model.exampleValue2, @"Target/Source binding did not product expected result. Expected: %d, Actual: %d",self.model.exampleValue2,self.model.exampleValue1);
+    
+    
+    for (WSObservationBinding *binder in bindings) {
+        [binding invalidate];
+        [[self allBlockBasedObservations] removeObject:binder];
+    }
 }
 @end


### PR DESCRIPTION
The changes provide the ability to bind a source keypath to a target keypath. Optionally, a reverse binding can be specified so that updates to the target keypath are reflected in the source. 
