### PR TITLE
Added ability to execute the binding immediately

### DIFF
--- a/KVOBlockBinding/NSObject+KVOBlockBinding.h
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.h
@@ -76,6 +76,17 @@ typedef void (^WSObservationBlock)(id observed, NSDictionary *change);
  * @return An array containing the binding and it's reverse, if specified. This does NOT need to be retained
  */
 - (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath addReverseBinding:(BOOL)addReverseBinding;
+/**
+ * Same as above except that it will perform an immediate update of the target if executeBinding is YES  
+ *
+ * @param source The source object to observe
+ * @param sourcePath The keypath of the property to observe on the source using KVO
+ * @param target The target object to observe
+ * @param targetPath The keypath of the property to observe on the target using KVO
+ * @param executeBinding update the target keypath immediately if YES
+ * @return An array containing the binding and it's reverse, if specified. This does NOT need to be retained
+ */
+- (NSMutableArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath addReverseBinding:(BOOL)addReverseBinding executeBinding:(BOOL)executeBinding;
 @end
 
 @interface NSObject (KVOBlockBinding)

--- a/KVOBlockBinding/NSObject+KVOBlockBinding.m
+++ b/KVOBlockBinding/NSObject+KVOBlockBinding.m
@@ -141,6 +141,18 @@
 
     return bindings;
 }
+- (NSArray *) bind:(id)source keyPath:(NSString *)sourcePath to:(id) target keyPath:(NSString *)targetPath addReverseBinding:(BOOL)addReverseBinding executeBinding:(BOOL)executeBinding {
+    NSArray *bindings = [self bind:source keyPath:sourcePath to: target keyPath:targetPath addReverseBinding:addReverseBinding];
+    
+    if (executeBinding) {
+        id value = [source valueForKey:sourcePath];
+        if (value == [NSNull null]) {
+            value = nil;
+        }
+        [target setValue: value forKey:targetPath];
+    }
+    return bindings;
+}
 
 @end
 

--- a/KVOBlockBindingTests/KVOBlockBindingTests.m
+++ b/KVOBlockBindingTests/KVOBlockBindingTests.m
@@ -95,7 +95,7 @@
 
 - (void) testTwoWayBinding
 {
-    NSMutableArray *bindings = [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES];
+    [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES];
     
     self.model.exampleValue1 = 1; // no change
     STAssertFalse(self.model.exampleValue2 == self.model.exampleValue1, @"Identical changes should not trigger an update of the target object");
@@ -106,22 +106,14 @@
     self.model.exampleValue2 = 20;
     STAssertTrue(self.model.exampleValue1 == self.model.exampleValue2, @"Target/Source binding did not product expected result. Expected: %d, Actual: %d",self.model.exampleValue2,self.model.exampleValue1);
     
-    
-    for (WSObservationBinding *binder in bindings) {
-        [binding invalidate];
-        [[self allBlockBasedObservations] removeObject:binder];
-    }
+    [self removeAllObservationsOn:self.model];
 }
 - (void) testExecuteBinding
 {
-    NSMutableArray *bindings = [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES executeBinding:YES];
+    [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES executeBinding:YES];
     
     STAssertTrue(self.model.exampleValue1 == self.model.exampleValue2, @"Execute binding did not product expected result. Expected: %d, Actual: %d",self.model.exampleValue1,self.model.exampleValue2);
     
-    
-    for (WSObservationBinding *binder in bindings) {
-        [binding invalidate];
-        [[self allBlockBasedObservations] removeObject:binder];
-    }
+    [self removeAllObservationsOn:self.model];
 }
 @end

--- a/KVOBlockBindingTests/KVOBlockBindingTests.m
+++ b/KVOBlockBindingTests/KVOBlockBindingTests.m
@@ -112,4 +112,16 @@
         [[self allBlockBasedObservations] removeObject:binder];
     }
 }
+- (void) testExecuteBinding
+{
+    NSMutableArray *bindings = [self bind:self.model keyPath:@"exampleValue1" to:self.model keyPath:@"exampleValue2" addReverseBinding:YES executeBinding:YES];
+    
+    STAssertTrue(self.model.exampleValue1 == self.model.exampleValue2, @"Execute binding did not product expected result. Expected: %d, Actual: %d",self.model.exampleValue1,self.model.exampleValue2);
+    
+    
+    for (WSObservationBinding *binder in bindings) {
+        [binding invalidate];
+        [[self allBlockBasedObservations] removeObject:binder];
+    }
+}
 @end


### PR DESCRIPTION
Two-way bindings are usually intended to keep two properties in sync.
With executeBindings specified, the target keypath is updated from the
source immediately, ensuring that both are in sync when the binding is
created.
